### PR TITLE
Set buffer size to 1 in projection

### DIFF
--- a/consumer.js
+++ b/consumer.js
@@ -1,7 +1,7 @@
 import log from "loglevel";
 
 export class Consumer {
-  constructor(subscription, eventAppeared, subscriptionDropped = null, bufferSize = 10, autoAck = false) {
+  constructor(subscription, eventAppeared, subscriptionDropped = null, bufferSize = 1, autoAck = false) {
     if (!subscriptionDropped) {
       subscriptionDropped = (subscription, reason, error) => {
         log.error(`Subscription dropped: ${reason}`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "event-store-consumer",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "dependencies": {
     "loglevel": "^1.6.1",
     "node-eventstore-client": "^0.2.4"


### PR DESCRIPTION
When the buffersize is > 1 the events will be handled synchronously. This can lead to event X to arrive first and event Y to arrive second but event Y to finish earlier.